### PR TITLE
Ignore previous frame in mp3_mute_frame

### DIFF
--- a/source/packmp3.cpp
+++ b/source/packmp3.cpp
@@ -2559,14 +2559,7 @@ INTERN inline bool mp3_mute_frame( mp3Frame* frame )
 	
 	// mute frame - this has to be done in order
 	// we assume that all previous frames are muted, too!
-	if ( frame->prev != NULL ) {
-		// make some room, use prev frame aux too!
-		frame->bit_reservoir += frame->prev->aux_size;
-		if ( frame->bit_reservoir >= 512 ) {
-			frame->prev->aux_size = frame->bit_reservoir - 511;
-			frame->bit_reservoir = 511;
-		} else frame->prev->aux_size = 0;
-	} else frame->bit_reservoir = 0;
+	frame->bit_reservoir = 0;
 	frame->aux_size = frame->frame_size - frame->fixed_size + frame->bit_reservoir;
 	if ( frame->next != NULL ) frame->aux_size -= frame->next->bit_reservoir;
 	frame->main_size = 0;


### PR DESCRIPTION
mp3_mute_frame manipulates the aux_size of the previous frame, but mp3_unmute_frame doesn't.
This leads to an inconsistency between aux_size in the encoder and decoder. In most cases this doesn't seem to be a problem.
However, in some rare cases, it leads to packMP3 crashing while trying to uncompress the .pmp file.