### PR TITLE
mp3_mute_frame: do not enforce bit reservoir usage

### DIFF
--- a/source/packmp3.cpp
+++ b/source/packmp3.cpp
@@ -2561,7 +2561,7 @@ INTERN inline bool mp3_mute_frame( mp3Frame* frame )
 	// we assume that all previous frames are muted, too!
 	// move aux data around the bit reservoirs only for files that already provide a
 	// bit reservoir. the decoder depends on this.
-	if ( frame->prev != NULL && i_bit_res != 0) {
+	if ( frame->prev != NULL && i_bit_res != 0 ) {
 		// make some room, use prev frame aux too!
 		frame->bit_reservoir += frame->prev->aux_size;
 		if ( frame->bit_reservoir >= 512 ) {

--- a/source/packmp3.cpp
+++ b/source/packmp3.cpp
@@ -2559,14 +2559,7 @@ INTERN inline bool mp3_mute_frame( mp3Frame* frame )
 	
 	// mute frame - this has to be done in order
 	// we assume that all previous frames are muted, too!
-	if ( frame->prev != NULL ) {
-		// make some room, use prev frame aux too!
-		frame->bit_reservoir += frame->prev->aux_size;
-		if ( frame->bit_reservoir >= 512 ) {
-			frame->prev->aux_size = frame->bit_reservoir - 511;
-			frame->bit_reservoir = 511;
-		} else frame->prev->aux_size = 0;
-	} else frame->bit_reservoir = 0;
+	frame->bit_reservoir = 0;
 	frame->aux_size = frame->frame_size - frame->fixed_size + frame->bit_reservoir;
 	if ( frame->next != NULL ) frame->aux_size -= frame->next->bit_reservoir;
 	frame->main_size = 0;

--- a/source/packmp3.cpp
+++ b/source/packmp3.cpp
@@ -2559,7 +2559,16 @@ INTERN inline bool mp3_mute_frame( mp3Frame* frame )
 	
 	// mute frame - this has to be done in order
 	// we assume that all previous frames are muted, too!
-	frame->bit_reservoir = 0;
+	// move aux data around the bit reservoirs only for files that already provide a
+	// bit reservoir. the decoder depends on this.
+	if ( frame->prev != NULL && i_bit_res != 0) {
+		// make some room, use prev frame aux too!
+		frame->bit_reservoir += frame->prev->aux_size;
+		if ( frame->bit_reservoir >= 512 ) {
+			frame->prev->aux_size = frame->bit_reservoir - 511;
+			frame->bit_reservoir = 511;
+		} else frame->prev->aux_size = 0;
+	} else frame->bit_reservoir = 0;
 	frame->aux_size = frame->frame_size - frame->fixed_size + frame->bit_reservoir;
 	if ( frame->next != NULL ) frame->aux_size -= frame->next->bit_reservoir;
 	frame->main_size = 0;


### PR DESCRIPTION
mp3_mute_frame tries to move aux data to the bit reservoirs of the frames during encoding,
which is undone during decoding. This is usually fine.
However, if the file did not use bit reservoirs to begin with, this is written in the encoded pmp file,
the decoder will assume that there is no data in the bit reservoirs and calculate aux_size wrongly.
This will lead to the decoder crashing.
Tested on 17 files for which at least 2 frames were muted. Before, 11 of those files would crash the
decoder. Now, all files encode and decode successfully.